### PR TITLE
Fixed enumerator initialization. Minor refactoring.

### DIFF
--- a/ErrorLogEnumerator.cs
+++ b/ErrorLogEnumerator.cs
@@ -32,15 +32,13 @@ namespace MyApp
             do
             {
                 _logCount++;
-                if (_logEnumerator.MoveNext())
-                {
-                    _currentErrorLog = _logEnumerator.Current;
-                }
-                else
+                if (!_logEnumerator.MoveNext())
                 {
                     return false;
                 }
-            } while (!_errorRegex.Match(_currentErrorLog).Success);
+
+            } while (!_errorRegex.Match(_logEnumerator.Current).Success);
+            _currentErrorLog = _logEnumerator.Current;
             _errorCount++;
             return true;
         }

--- a/LogFileEnumerator.cs
+++ b/LogFileEnumerator.cs
@@ -19,6 +19,19 @@ namespace MyApp
             _lineReader = File.ReadLines(logFileName).GetEnumerator();
             _currentBuffer = "";
             _currentLogEntry = "";
+            InitializeEnumeration();
+        }
+
+        public void InitializeEnumeration()
+        {
+            // First MoveNext stops when the next line contains a valid log entry
+            //      but the enumerator might contain an invalid log entry
+            //      if the log starts with some meta info (e.g. "Log started at: <time>")
+            MoveNext();
+            if (!newLogEntryRegex.Match(_currentLogEntry).Success)
+            {
+                MoveNext();
+            }
         }
 
         public bool MoveNext()


### PR DESCRIPTION
## Description

- Enumeration is now properly initialized. Before the changes, the first element was an empty line, and the second one included the first line of the log which is not a log message, only some meta info ("Log started at: <date>").
- ErrorLogEnumerator was assigning the currently enumerated element's variable unnecessarily for every line which did not include an error in its MoveNext() function. Now it only assigns once when it actually encounters an error.